### PR TITLE
Added tradrack LCD menus

### DIFF
--- a/Mods/tradrack_mmu_support/tradrack_menus.cfg
+++ b/Mods/tradrack_mmu_support/tradrack_menus.cfg
@@ -1,0 +1,92 @@
+# Menus for tradrack
+# Just include this cfg on printer.cfg or reference to it.
+
+[menu __main __tradrack]
+type: list
+name: Tradrack
+index: 2
+
+[menu __main __tradrack __tr_home]
+type: command
+enable: {not printer.idle_timeout.state == "Printing"}
+name: Home tradrack
+gcode:
+  TR_HOME
+
+[menu __main __tradrack __tr_resume]
+type: command
+enable: {not printer.idle_timeout.state == "Printing"}
+name: Resume
+gcode:
+  TR_RESUME
+
+[menu __main __tradrack __tr_unload_toolhead]
+type: command
+enable: {not printer.idle_timeout.state == "Printing"}
+name: Unload Toolhead
+gcode:
+  TR_UNLOAD_TOOLHEAD
+
+[menu __main __tradrack __tr_servo_up]
+type: command
+enable: {not printer.idle_timeout.state == "Printing"}
+name: Servo UP
+gcode:
+  TR_SERVO_UP
+
+[menu __main __tradrack __tr_servo_down]
+type: command
+enable: {not printer.idle_timeout.state == "Printing"}
+name: Servo DOWN
+gcode:
+  TR_SERVO_DOWN
+
+[menu __main __tradrack __tr_go_lane]
+type: input
+name: Go to Lane: {'%d' % menu.input}
+enable: {not printer.idle_timeout.state == "Printing"}
+input: {printer.save_variables.tr_active_lane | default(0)}
+input_min: 0
+input_max: {printer.configfile.config.trad_rack.lane_count}
+input_step: 1
+gcode:
+  TR_GO_TO_LANE LANE={menu.input | int}
+
+[menu __main __tradrack __tr_load_lane]
+type: input
+name: Load Lane: {'%.d' % menu.input}
+enable: {not printer.idle_timeout.state == "Printing"}
+input: 0
+input_min: 0
+input_max: {printer.configfile.config.trad_rack.lane_count}
+input_step: 1
+gcode:
+  TR_LOAD_LANE LANE={menu.input | int}
+
+[menu __main __tradrack __tr_load_toolhead]
+type: input
+name: Load Toolhead: {'%.d' % menu.input}
+enable: {not printer.idle_timeout.state == "Printing"}
+input: 0
+input_min: 0
+input_max: {printer.configfile.config.trad_rack.lane_count}
+input_step: 1
+gcode:
+  TR_LOAD_TOOLHEAD LANE={menu.input | int}
+
+[menu __main __tradrack __tr_active_lane]
+type: input
+name: Set active Lane: {'%.d' % menu.input}
+enable: {not printer.idle_timeout.state == "Printing"}
+input: 0
+input_min: 0
+input_max: {printer.configfile.config.trad_rack.lane_count}
+input_step: 1
+gcode:
+  TR_SET_ACTIVE_LANE LANE={menu.input | int}
+
+[menu __main __tradrack __discard_bowden]
+type: command
+name: Discard bowden lenght
+gcode:
+  TR_DISCARD_BOWDEN_LENGTHS


### PR DESCRIPTION
Added tradrack LCD menus to operate the tradrack "headless" to solve errors trough the LCD without PC/tablet/klipperscreen